### PR TITLE
Fix Sign In button

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.jsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.jsx
@@ -7,6 +7,8 @@ import { toast } from "react-toastify";
 import LoadingSpinner from "../Spinner/LoadingSpinner";
 import { useLogOutMutation } from "../../store/slices/ApiSlices/userApiSlice";
 import { clearLocalStorage } from "../../Utils/Functions";
+import { logOut as logOutReducer } from "../../store/slices/userSlice";
+import { useDispatch } from "react-redux";
 import "./confirmationModal.css";
 
 /**
@@ -26,6 +28,7 @@ const ConfirmationModal = ({
 }) => {
   const navigate = useNavigate();
   const [logOut] = useLogOutMutation();
+  const dispatch = useDispatch();
 
   useEffect(() => {
     // User deletion
@@ -34,6 +37,7 @@ const ConfirmationModal = ({
       toast.success(item.successMsg);
       logOut();
       clearLocalStorage();
+      dispatch(logOutReducer());
       return navigate(item.redirect);
     }
 

--- a/src/pages/homepage/Homepage.jsx
+++ b/src/pages/homepage/Homepage.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { NavLink, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import hero from "../../images/hero.svg";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 import "./homepage.css";
@@ -31,9 +31,6 @@ const Homepage = () => {
             <span>TrackU</span> gives you an environment where you can create and keep your personal
             projects updated until completion. Makes your management process easier.
           </p>
-          <NavLink className="homepage__btn" to="/registration">
-            Start Now
-          </NavLink>
         </div>
         <div className="homepage__image-container">
           <img

--- a/src/pages/projectList/projectList.css
+++ b/src/pages/projectList/projectList.css
@@ -40,7 +40,9 @@
   width: 100%;
 }
 
+/* Position relative is used to center spinner */
 .projectList__container {
+  position: relative;
   justify-content: space-between;
   gap: 3rem;
   height: 90%;


### PR DESCRIPTION
- Issue: Sign in button not showing after user deletes account.
Fixed by dispatching log out reducer to reset the user state.
- Deletes Start Now link in the homepage because it had the same functionality as the Sign In button.